### PR TITLE
Catch up on test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Generate HTML coverage report
         run: |
-          pytest --cov=app --cov=routes --cov=utils --cov-report=html:htmlcov
+          pytest --cov=app --cov=routes --cov=utils --cov-report=html:htmlcov --cov-fail-under=80
 
       - name: Verify coverage report exists
         run: ls htmlcov || echo "Coverage report not generated"

--- a/app.py
+++ b/app.py
@@ -4,13 +4,13 @@ from flask import Flask, request
 from flask_cors import CORS
 from flask_smorest import Api
 from os import getenv
-from routes.pyro_assets import blp as pyro_assets_blp
-from routes.whoami import blp as whoami_blp
-from routes.work_item_details import blp as main_blp
+from routes import pyro_assets
+from routes import whoami
+from routes import work_item_details
 from werkzeug.middleware.proxy_fix import ProxyFix
 import jwt
-import requests
 import logging
+import requests
 
 load_dotenv()
 
@@ -47,9 +47,9 @@ app.config["API_SPEC_OPTIONS"] = {
 api = Api(app)
 
 # Register all your blueprints with this, not `app`
-api.register_blueprint(main_blp)
-api.register_blueprint(whoami_blp)
-api.register_blueprint(pyro_assets_blp)
+api.register_blueprint(work_item_details.blp)
+api.register_blueprint(whoami.blp)
+api.register_blueprint(pyro_assets.blp)
 
 TENANT_ID = getenv("AZURE_TENANT_ID")
 AUDIENCE = getenv("AZURE_CLIENT_ID")

--- a/routes/work_item_details.py
+++ b/routes/work_item_details.py
@@ -12,7 +12,7 @@ from qualer_sdk import (
     ClientAssetsApi,
     ClientAssetAttributesApi)
 
-blp = Blueprint("work_item_details", __name__, url_prefix="/")
+blp = Blueprint("work-item-details", __name__, url_prefix="/")
 
 
 def get_work_item_details_for_tus(item_no):
@@ -79,7 +79,7 @@ def get_work_item_details_for_tus(item_no):
         "assetAttributes": client_asset_attributes
     }
 
-@blp.route("/work_item_details")
+@blp.route("/work-item-details")
 class WorkItemDetails(MethodView):
     @require_auth
     @blp.doc(security=[{"BearerAuth": []}])

--- a/routes/work_item_details.py
+++ b/routes/work_item_details.py
@@ -15,6 +15,70 @@ from qualer_sdk import (
 blp = Blueprint("work_item_details", __name__, url_prefix="/")
 
 
+def get_work_item_details_for_tus(item_no):
+    pattern = r"^(56561-)?\d{6}(\.\d{2})?(-\d{2})(R\d{1,2})?$"
+    if not re.match(pattern, item_no):
+        raise ValueError("Invalid work item number format.")
+
+    client = make_qualer_client()
+
+    soi_api = ServiceOrderItemsApi(client)
+    work_items = soi_api.get_work_items_0(work_item_number=item_no)
+
+    if len(work_items) == 0:
+        raise ValueError(
+            "No work items found for the given work item number."
+            )
+    if len(work_items) > 1:
+        raise ValueError(
+            "Multiple work items found for the given work item number."
+            )
+
+    item = work_items[0]
+    service_order_id = item.service_order_id
+    asset_id = item.asset_id
+    client_company_id = item.client_company_id
+
+    for field in [service_order_id, asset_id, client_company_id]:
+        if field is None:
+            raise ValueError(f"Missing required field: {field}")
+
+    with ThreadPoolExecutor() as executor:
+        future_client_asset = executor.submit(
+            ClientAssetsApi(client).get_asset,
+            asset_id=asset_id
+            )
+        future_attributes = executor.submit(
+            ClientAssetAttributesApi(client).get_asset_attributes,
+            asset_id=asset_id
+            )
+        future_service_order = executor.submit(
+            ServiceOrdersApi(client).get_work_order,
+            service_order_id=service_order_id
+            )
+
+        client_asset = future_client_asset.result()
+        client_asset_attributes = future_attributes.result()
+        service_order = future_service_order.result()
+
+    return {
+        "clientCompanyId": client_company_id,
+        "serviceOrderId": service_order_id,
+        "assetId": asset_id,
+        "certificateNumber": item.certificate_number,
+        "assetName": client_asset.asset_name,
+        "assetMaker": client_asset.asset_maker,
+        "assetTag": client_asset.asset_tag,
+        "serialNumber": client_asset.serial_number,
+        "manufacturerPartNumber": client_asset.manufacturer_part_number,
+        "categoryName": client_asset.category_name,
+        "rootCategoryName": client_asset.root_category_name,
+        "productManufacturer": client_asset.product_manufacturer,
+        "productName": client_asset.product_name,
+        "purchaseOrderNumber": service_order.po_number,
+        "assetAttributes": client_asset_attributes
+    }
+
 @blp.route("/work_item_details")
 class WorkItemDetails(MethodView):
     @require_auth
@@ -24,70 +88,6 @@ class WorkItemDetails(MethodView):
     def get(self, workItemNumber):
         if not workItemNumber:
             abort(400, message="Missing workItemNumber")
-        
-        def get_work_item_details_for_tus(item_no):
-            pattern = r"^(56561-)?\d{6}(\.\d{2})?(-\d{2})(R\d{1,2})?$"
-            if not re.match(pattern, item_no):
-                raise ValueError("Invalid work item number format.")
-
-            client = make_qualer_client()
-
-            soi_api = ServiceOrderItemsApi(client)
-            work_items = soi_api.get_work_items_0(work_item_number=item_no)
-
-            if len(work_items) == 0:
-                raise ValueError(
-                    "No work items found for the given work item number."
-                    )
-            if len(work_items) > 1:
-                raise ValueError(
-                    "Multiple work items found for the given work item number."
-                    )
-
-            item = work_items[0]
-            service_order_id = item.service_order_id
-            asset_id = item.asset_id
-            client_company_id = item.client_company_id
-
-            for field in [service_order_id, asset_id, client_company_id]:
-                if field is None:
-                    raise ValueError(f"Missing required field: {field}")
-
-            with ThreadPoolExecutor() as executor:
-                future_client_asset = executor.submit(
-                    ClientAssetsApi(client).get_asset,
-                    asset_id=asset_id
-                    )
-                future_attributes = executor.submit(
-                    ClientAssetAttributesApi(client).get_asset_attributes,
-                    asset_id=asset_id
-                    )
-                future_service_order = executor.submit(
-                    ServiceOrdersApi(client).get_work_order,
-                    service_order_id=service_order_id
-                    )
-
-                client_asset = future_client_asset.result()
-                client_asset_attributes = future_attributes.result()
-                service_order = future_service_order.result()
-
-            return {
-                "clientCompanyId": client_company_id,
-                "serviceOrderId": service_order_id,
-                "assetId": asset_id,
-                "certificateNumber": item.certificate_number,
-                "assetName": client_asset.asset_name,
-                "assetMaker": client_asset.asset_maker,
-                "assetTag": client_asset.asset_tag,
-                "serialNumber": client_asset.serial_number,
-                "manufacturerPartNumber": client_asset.manufacturer_part_number,
-                "categoryName": client_asset.category_name,
-                "rootCategoryName": client_asset.root_category_name,
-                "productManufacturer": client_asset.product_manufacturer,
-                "productName": client_asset.product_name,
-                "purchaseOrderNumber": service_order.po_number,
-                "assetAttributes": client_asset_attributes
-            }
 
         try:
             return get_work_item_details_for_tus(workItemNumber)

--- a/routes/work_item_details.py
+++ b/routes/work_item_details.py
@@ -2,7 +2,6 @@
 from concurrent.futures import ThreadPoolExecutor
 from flask.views import MethodView
 from flask_smorest import Blueprint, abort
-from os import getenv
 from schemas import WorkItemDetailsSchema, WorkItemDetailsQuerySchema
 from utils.auth import require_auth
 import re

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import tests.mock_view_bindings
 from app import app as flask_app
 import pytest
-from get_token import get_access_token
+from utils.get_token import get_access_token
 
 
 @pytest.fixture(scope="session")

--- a/tests/mock_view_bindings.py
+++ b/tests/mock_view_bindings.py
@@ -23,12 +23,22 @@ if os.getenv("SKIP_AUTH", "false").lower() == "true":
             "user": "testuser@example.com",
             "sub": "fake-subject"
         }
-
-    # /work_item_details
+    
+    # /work-item-details
     def fake_work_item_details():
         if resp := fake_auth_check():
             return resp
         wid = request.args.get("workItemNumber")
+
+        # Handle missing workItemNumber parameter
+        if not wid:
+            return Response("Missing workItemNumber", 400)
+
+        # Handle invalid workItemNumber format
+        import re
+        pattern = r"^(56561-)?\d{6}(\.\d{2})?(-\d{2})(R\d{1,2})?$"
+        if not re.match(pattern, wid):
+            return Response("Invalid work item number format.", 500)
 
         if wid == "56561-067667-01":
             return {
@@ -85,5 +95,5 @@ if os.getenv("SKIP_AUTH", "false").lower() == "true":
         ]
 
     app.view_functions["whoami.Whoami"] = fake_whoami
-    app.view_functions["work_item_details.WorkItemDetails"] = fake_work_item_details
+    app.view_functions["work-item-details.WorkItemDetails"] = fake_work_item_details
     app.view_functions["pyro-assets.PyroAssets"] = fake_pyro_assets

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,113 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from flask import Flask, g, jsonify
+import jwt
+
+import utils.auth as auth
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+
+    @app.route("/protected")
+    @auth.require_auth
+    def protected():
+        return jsonify({"claims": g.claims})
+
+    return app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+def test_require_auth_no_auth_header(client):
+    resp = client.get("/protected")
+    assert resp.status_code == 401
+    assert "WWW-Authenticate" in resp.headers
+
+def test_require_auth_invalid_auth_header(client):
+    resp = client.get("/protected", headers={"Authorization": "InvalidToken"})
+    assert resp.status_code == 401
+    assert "WWW-Authenticate" in resp.headers
+
+@patch("utils.auth.validate_token")
+def test_require_auth_valid_token(mock_validate_token, client):
+    mock_validate_token.return_value = {"sub": "user1", "scp": "access_as_user"}
+    resp = client.get("/protected", headers={"Authorization": "Bearer validtoken"})
+    assert resp.status_code == 200
+    assert resp.json["claims"]["sub"] == "user1"
+
+@patch("utils.auth.validate_token")
+def test_require_auth_invalid_token(mock_validate_token, client):
+    mock_validate_token.side_effect = Exception("Invalid token")
+    resp = client.get("/protected", headers={"Authorization": "Bearer badtoken"})
+    assert resp.status_code == 401
+    assert resp.json["error"] == "Invalid token"
+
+@patch("utils.auth.requests.get")
+def test_load_openid_config_caches(mock_get, monkeypatch):
+    # Reset cache
+    auth._openid_config = None
+    auth._jwks = None
+
+    mock_openid = {"jwks_uri": "https://example.com/jwks", "issuer": "issuer"}
+    mock_jwks = {"keys": [{"kid": "abc"}]}
+    mock_get.side_effect = [
+        MagicMock(json=lambda: mock_openid),
+        MagicMock(json=lambda: mock_jwks)
+    ]
+    config, jwks = auth.load_openid_config()
+    assert config == mock_openid
+    assert jwks == mock_jwks
+
+    # Should not call requests.get again
+    mock_get.reset_mock()
+    config2, jwks2 = auth.load_openid_config()
+    assert config2 == mock_openid
+    assert jwks2 == mock_jwks
+    mock_get.assert_not_called()
+
+@patch("utils.auth.jwt.get_unverified_header")
+@patch("utils.auth.RSAAlgorithm.from_jwk")
+@patch("utils.auth.jwt.decode")
+@patch("utils.auth.load_openid_config")
+def test_validate_token_success(mock_load_config, mock_decode, mock_from_jwk, mock_get_header):
+    mock_load_config.return_value = (
+        {"issuer": "issuer"},
+        {"keys": [{"kid": "abc"}]}
+    )
+    mock_get_header.return_value = {"kid": "abc"}
+    mock_from_jwk.return_value = "publickey"
+    mock_decode.return_value = {"scp": "access_as_user", "sub": "user1"}
+
+    token = "sometoken"
+    result = auth.validate_token(token)
+    assert result["sub"] == "user1"
+    mock_decode.assert_called_once()
+
+@patch("utils.auth.jwt.get_unverified_header")
+@patch("utils.auth.load_openid_config")
+def test_validate_token_missing_kid(mock_load_config, mock_get_header):
+    mock_load_config.return_value = (
+        {"issuer": "issuer"},
+        {"keys": [{"kid": "other"}]}
+    )
+    mock_get_header.return_value = {"kid": "abc"}
+    with pytest.raises(StopIteration):
+        auth.validate_token("token")
+
+@patch("utils.auth.jwt.get_unverified_header")
+@patch("utils.auth.RSAAlgorithm.from_jwk")
+@patch("utils.auth.jwt.decode")
+@patch("utils.auth.load_openid_config")
+def test_validate_token_missing_scope(mock_load_config, mock_decode, mock_from_jwk, mock_get_header):
+    mock_load_config.return_value = (
+        {"issuer": "issuer"},
+        {"keys": [{"kid": "abc"}]}
+    )
+    mock_get_header.return_value = {"kid": "abc"}
+    mock_from_jwk.return_value = "publickey"
+    mock_decode.return_value = {"scp": "other_scope"}
+
+    with pytest.raises(jwt.InvalidTokenError):
+        auth.validate_token("token")

--- a/tests/test_get_token.py
+++ b/tests/test_get_token.py
@@ -1,0 +1,49 @@
+import os
+import pytest
+from unittest import mock
+
+import utils.get_token as get_token_mod
+
+@mock.patch.dict(os.environ, {"SKIP_AUTH": "true"})
+def test_get_access_token_skip_auth(monkeypatch, capsys):
+    token = get_token_mod.get_access_token()
+    assert token == "fake-token"
+    captured = capsys.readouterr()
+    assert "Skipping get_access_token()" in captured.out
+
+@mock.patch("msal.PublicClientApplication")
+@mock.patch("dotenv.load_dotenv")
+def test_get_access_token_success(mock_load_dotenv, mock_pca, monkeypatch):
+    # Set required env vars
+    monkeypatch.setenv("SKIP_AUTH", "false")
+    monkeypatch.setenv("AZURE_CLIENT_ID", "test-client-id")
+    monkeypatch.setenv("AZURE_TENANT_ID", "test-tenant-id")
+
+    # Mock msal app and its method
+    mock_app = mock.Mock()
+    mock_app.acquire_token_interactive.return_value = {"access_token": "real-token"}
+    mock_pca.return_value = mock_app
+
+    token = get_token_mod.get_access_token()
+    assert token == "real-token"
+    mock_app.acquire_token_interactive.assert_called_once()
+
+@mock.patch("msal.PublicClientApplication")
+@mock.patch("dotenv.load_dotenv")
+def test_get_access_token_error(mock_load_dotenv, mock_pca, monkeypatch, capsys):
+    monkeypatch.setenv("SKIP_AUTH", "false")
+    monkeypatch.setenv("AZURE_CLIENT_ID", "test-client-id")
+    monkeypatch.setenv("AZURE_TENANT_ID", "test-tenant-id")
+
+    mock_app = mock.Mock()
+    mock_app.acquire_token_interactive.return_value = {
+        "error": "invalid_grant",
+        "error_description": "Some error"
+    }
+    mock_pca.return_value = mock_app
+
+    with pytest.raises(KeyError):
+        # Should raise because "access_token" is missing
+        get_token_mod.get_access_token()
+    captured = capsys.readouterr()
+    assert "Error acquiring token:" in captured.out

--- a/tests/test_get_work_item_details_for_tus.py
+++ b/tests/test_get_work_item_details_for_tus.py
@@ -1,0 +1,46 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from routes.work_item_details import get_work_item_details_for_tus
+
+@patch("routes.work_item_details.make_qualer_client")
+@patch("routes.work_item_details.ServiceOrderItemsApi")
+@patch("routes.work_item_details.ClientAssetsApi")
+@patch("routes.work_item_details.ClientAssetAttributesApi")
+@patch("routes.work_item_details.ServiceOrdersApi")
+def test_get_work_item_details_for_tus_success(
+    mock_orders_api, mock_attr_api, mock_assets_api, mock_soi_api, mock_make_client
+):
+    mock_client = MagicMock()
+    mock_make_client.return_value = mock_client
+
+    work_item = MagicMock()
+    work_item.service_order_id = 123
+    work_item.asset_id = 456
+    work_item.client_company_id = 789
+    work_item.certificate_number = "CERT-XYZ"
+    mock_soi_api.return_value.get_work_items_0.return_value = [work_item]
+
+    asset = MagicMock()
+    asset.asset_name = "Test"
+    asset.asset_maker = "Maker"
+    asset.asset_tag = "Tag"
+    asset.serial_number = "SN"
+    asset.manufacturer_part_number = "MPN"
+    asset.category_name = "Cat"
+    asset.root_category_name = "RootCat"
+    asset.product_manufacturer = "ProdMfg"
+    asset.product_name = "Prod"
+    mock_assets_api.return_value.get_asset.return_value = asset
+
+    mock_attr_api.return_value.get_asset_attributes.return_value = {"calibration_date": "2023-01-01"}
+
+    order = MagicMock()
+    order.po_number = "PO123"
+    mock_orders_api.return_value.get_work_order.return_value = order
+
+    result = get_work_item_details_for_tus("56561-000001-01")
+
+    assert result["assetId"] == 456
+    assert result["certificateNumber"] == "CERT-XYZ"
+    assert result["purchaseOrderNumber"] == "PO123"
+    assert result["assetAttributes"] == {"calibration_date": "2023-01-01"}

--- a/tests/test_qualer_client.py
+++ b/tests/test_qualer_client.py
@@ -1,0 +1,18 @@
+# tests/test_qualer_client.py
+import os
+import pytest
+from utils.qualer_client import make_qualer_client
+
+@pytest.fixture
+def patch_env(monkeypatch):
+    monkeypatch.setenv("QUALER_API_KEY", "fake-qualer-token")
+
+def test_make_qualer_client_sets_host_and_token(patch_env):
+    client = make_qualer_client()
+
+    # Check the host
+    assert client.configuration.host == "https://jgiquality.qualer.com"
+
+    # Check the authorization header
+    auth_header = client.default_headers.get("Authorization")
+    assert auth_header == "Api-Token fake-qualer-token"

--- a/tests/test_service_order_details.py
+++ b/tests/test_service_order_details.py
@@ -53,7 +53,7 @@ IDS = [number for number, _ in SUCCESS_CASES]
 )
 def test_work_item_details_route_with_auth(client, auth_token, work_item_number, expected):
     resp = client.get(
-        f"/work_item_details?workItemNumber={work_item_number}",
+        f"/work-item-details?workItemNumber={work_item_number}",
         headers={"Authorization": f"Bearer {auth_token}"}
     )
     assert resp.status_code == 200
@@ -63,6 +63,6 @@ def test_work_item_details_route_with_auth(client, auth_token, work_item_number,
 
 
 def test_work_item_details_route_without_auth(client):
-    resp = client.get("/work_item_details?workItemNumber=56561-067667-01")
+    resp = client.get("/work-item-details?workItemNumber=56561-067667-01")
     assert resp.status_code == 401
     assert resp.text == "Unauthorized"

--- a/tests/test_work_item_details.py
+++ b/tests/test_work_item_details.py
@@ -50,7 +50,7 @@ def test_work_item_details_success(client, auth_token, mock_sdk_calls):
     assert mock_sdk_calls == "mocked"
 
     response = client.get(
-        "/work_item_details?workItemNumber=56561-067667-01",
+        "/work-item-details?workItemNumber=56561-067667-01",
         headers={"Authorization": f"Bearer {auth_token}"}
     )
 
@@ -75,3 +75,19 @@ def test_work_item_details_success(client, auth_token, mock_sdk_calls):
     }
     diff = DeepDiff(data, expected, ignore_order=True)
     assert not diff, f"Response data does not match expected: {diff}"
+
+def test_missing_work_item_number(client, auth_token):
+    response = client.get(
+        "/work-item-details",  # no query param
+        headers={"Authorization": f"Bearer {auth_token}"}
+    )
+    assert response.status_code == 400
+    assert "Missing workItemNumber" in response.get_data(as_text=True)
+
+def test_invalid_work_item_number_format(client, auth_token):
+    response = client.get(
+        "/work-item-details?workItemNumber=INVALID",
+        headers={"Authorization": f"Bearer {auth_token}"}
+    )
+    assert response.status_code == 500
+    assert "Invalid work item number format" in response.get_data(as_text=True)

--- a/tests/test_work_item_details.py
+++ b/tests/test_work_item_details.py
@@ -1,0 +1,77 @@
+# tests/test_work_item_details.py
+import pytest
+from unittest.mock import patch, MagicMock
+from deepdiff import DeepDiff
+
+@pytest.fixture
+def mock_sdk_calls():
+    with patch("routes.work_item_details.make_qualer_client") as mock_make_client, \
+         patch("routes.work_item_details.ServiceOrderItemsApi") as mock_soi_api, \
+         patch("routes.work_item_details.ClientAssetsApi") as mock_assets_api, \
+         patch("routes.work_item_details.ClientAssetAttributesApi") as mock_attr_api, \
+         patch("routes.work_item_details.ServiceOrdersApi") as mock_orders_api:
+
+        mock_client = MagicMock()
+        mock_make_client.return_value = mock_client
+
+        # Mock work item
+        mock_work_item = MagicMock()
+        mock_work_item.service_order_id = 123456
+        mock_work_item.asset_id = 8888
+        mock_work_item.client_company_id = 9999
+        mock_work_item.certificate_number = "FAKE-000000"
+        mock_soi_api.return_value.get_work_items_0.return_value = [mock_work_item]
+
+        # Mock asset
+        mock_asset = MagicMock()
+        mock_asset.asset_name = "Test Asset"
+        mock_asset.asset_maker = "Test Maker"
+        mock_asset.asset_tag = "TAG-123"
+        mock_asset.serial_number = "SN-001"
+        mock_asset.manufacturer_part_number = "MPN-XYZ"
+        mock_asset.category_name = "Tools"
+        mock_asset.root_category_name = "Equipment"
+        mock_asset.product_manufacturer = "Acme"
+        mock_asset.product_name = "Caliper"
+        mock_assets_api.return_value.get_asset.return_value = mock_asset
+
+        # Mock attributes
+        mock_attr_api.return_value.get_asset_attributes.return_value = {}
+
+        # Mock service order
+        mock_order = MagicMock()
+        mock_order.po_number = "PO-987654"
+        mock_orders_api.return_value.get_work_order.return_value = mock_order
+
+        yield "mocked"
+        
+
+def test_work_item_details_success(client, auth_token, mock_sdk_calls):
+    assert mock_sdk_calls == "mocked"
+
+    response = client.get(
+        "/work_item_details?workItemNumber=56561-067667-01",
+        headers={"Authorization": f"Bearer {auth_token}"}
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    expected = {
+        'assetAttributes': {},
+        'assetId': 1270490,
+        'assetMaker': 'COL-MET',
+        'assetName': 'Chrome Plus, Oven No. 13, W-CPI-4143, TUS',
+        'assetTag': 'W-CPI-4143, TUS',
+        'categoryName': 'Thermometer',
+        'certificateNumber': '56561-067667-01',
+        'clientCompanyId': 57283,
+        'manufacturerPartNumber': 'GENERIC 2354',
+        'productManufacturer': 'Unidentified',
+        'productName': 'Thermometers',
+        'purchaseOrderNumber': 'CHR001150',
+        'rootCategoryName': 'Thermometers',
+        'serialNumber': 'OVEN NO. 13',
+        'serviceOrderId': 1171585
+    }
+    diff = DeepDiff(data, expected, ignore_order=True)
+    assert not diff, f"Response data does not match expected: {diff}"

--- a/utils/get_token.py
+++ b/utils/get_token.py
@@ -1,4 +1,4 @@
-# get_token.py
+# utils/get_token.py
 import msal
 import os
 


### PR DESCRIPTION
## Pull Request Overview

This PR increases test coverage by adding new tests for work item details, token acquisition, and authentication while enforcing a minimum 80% coverage in CI.  
- Update to CI workflow to fail if coverage is below 80%.  
- New tests added for endpoint behaviors and token validation.  
- Route names updated from underscored to dashed style for consistency.

### Reviewed Changes

Copilot reviewed 12 out of 12 changed files in this pull request and generated 1 comment.

<details>
<summary>Show a summary per file</summary>

| File                                  | Description                                                        |
| ------------------------------------- | ------------------------------------------------------------------ |
| utils/get_token.py                    | Updated header comment                                               |
| tests/test_work_item_details.py       | Added tests for work item details endpoint behavior                 |
| tests/test_service_order_details.py    | Updated route name in tests                                          |
| tests/test_qualer_client.py           | Added tests for qualer client functionality                           |
| tests/test_get_work_item_details_for_tus.py  | New tests for get_work_item_details_for_tus functionality           |
| tests/test_get_token.py                | Added tests for token retrieval functionality                         |
| tests/test_auth.py                     | Added tests for authentication and token validation                     |
| tests/mock_view_bindings.py            | Updated route name and added explicit error handling for missing params  |
| tests/conftest.py                      | Updated import for get_access_token                                      |
| routes/work_item_details.py            | Updated blueprint and routes to use consistent dashed naming for routes    |
| app.py                                | Adjusted blueprint registrations for new route naming                     |
| .github/workflows/ci.yml               | Enforced a minimum 80% coverage threshold in CI                           |
</details>
